### PR TITLE
bump rubyzip because of CVE-2019-16892

### DIFF
--- a/plaintext.gemspec
+++ b/plaintext.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '>2.2.1 '
   spec.add_dependency 'nokogiri', '~> 1.10', '>= 1.10.4'
-  spec.add_dependency 'rubyzip', '~> 1.2.1'
+  spec.add_dependency 'rubyzip', '~> 1.3.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'rake', '~> 12.0'


### PR DESCRIPTION
See https://nvd.nist.gov/vuln/detail/CVE-2019-16892 for details.