### PR TITLE
Resolver returns nil if the handler returns nil

### DIFF
--- a/lib/plaintext/resolver.rb
+++ b/lib/plaintext/resolver.rb
@@ -36,8 +36,9 @@ module Plaintext
     # for the file type.
     def text
       if handler = find_handler and
-          text = +handler.text(@file, max_size: max_plaintext_bytes)
+          text = handler.text(@file, max_size: max_plaintext_bytes)
 
+        text = +text
         text.gsub!(/\s+/m, ' ')
         text.strip!
         text.mb_chars.compose.limit(max_plaintext_bytes).to_s

--- a/spec/lib/file_handler/resolver_spec.rb
+++ b/spec/lib/file_handler/resolver_spec.rb
@@ -3,12 +3,26 @@
 require 'spec_helper'
 
 describe Plaintext::Resolver do
-  it 'can deal with frozen string returned by the handler' do
+  subject(:resolver) do
     file = File.new('spec/fixtures/files/text.txt', 'r')
-    resolver = described_class.new(file, 'text/plain')
+    described_class.new(file, 'text/plain')
+  end
+  let(:handler) { resolver.send(:find_handler) }
 
+  it 'squishes and strips the text returned by the handler' do
+    allow(handler).to receive(:text).and_return("  hello \n \n world! ")
+
+    expect(resolver.text).to eq("hello world!")
+  end
+
+  it 'returns nil if the handler returns nil' do
+    allow(handler).to receive(:text).and_return(nil)
+
+    expect(resolver.text).to be_nil
+  end
+
+  it 'can deal with frozen string returned by the handler' do
     # make the handler return a frozen string
-    handler = resolver.send(:find_handler)
     allow(handler).to receive(:text).and_wrap_original { |m, *args| m.call(*args).freeze }
 
     expect(resolver.text).to match(/lorem ipsum/)


### PR DESCRIPTION
This avoids a "NoMethodError: undefined method '+@' for nil".