### PR TITLE
Add preserve_whitespace option to Resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,12 @@ fulltext = Plaintext::Resolver.new(file, content_type).text
 To limit the number of bytes returned (default is 4MB), set the
 `max_plaintext_bytes` property on the resolver instance before calling `text`.
 
+All whitespace is collapsed into single spaces by default. To keep the line
+structure emitted by the extraction command instead, set `preserve_whitespace`
+on the resolver instance before calling `text`. That is the full document
+structure for PDF, RTF and plain text, while the handlers for the zipped XML
+formats join their text elements with a space.
+
 ## License
 
 The `plaintext` gem is free software; you can redistribute it and/or modify it under the terms of the GNU General 

--- a/lib/plaintext/resolver.rb
+++ b/lib/plaintext/resolver.rb
@@ -6,6 +6,10 @@ module Plaintext
     # maximum length of returned plain text in bytes. Default: 4MB
     attr_accessor :max_plaintext_bytes
 
+    # keep the whitespace emitted by the handler instead of collapsing it
+    # into single spaces. Default: false
+    attr_accessor :preserve_whitespace
+
     class << self
       attr_accessor :cached_file_handlers
 
@@ -29,6 +33,7 @@ module Plaintext
       @file = file
       @content_type = content_type
       @max_plaintext_bytes = 4_194_304 # 4 megabytes
+      @preserve_whitespace = false
     end
 
 
@@ -38,9 +43,11 @@ module Plaintext
       if handler = find_handler and
           text = handler.text(@file, max_size: max_plaintext_bytes)
 
-        text = +text
-        text.gsub!(/\s+/m, ' ')
-        text.strip!
+        unless preserve_whitespace
+          text = +text
+          text.gsub!(/\s+/m, ' ')
+          text.strip!
+        end
         text.unicode_normalize(:nfc).truncate_bytes(max_plaintext_bytes, omission: nil)
       end
     end

--- a/spec/lib/file_handler/external_command_handler/pdf_handler_spec.rb
+++ b/spec/lib/file_handler/external_command_handler/pdf_handler_spec.rb
@@ -14,6 +14,17 @@ describe Plaintext::PdfHandler do
       expect(Plaintext::Resolver.new(file, 'application/pdf').text).to match /lorem ipsum fulltext find me!/
     end
 
+    it 'keeps the line structure if the resolver preserves whitespace' do
+      file = File.new('spec/fixtures/files/text.pdf', 'r')
+
+      squished = Plaintext::Resolver.new(file, 'application/pdf')
+      preserved = Plaintext::Resolver.new(file, 'application/pdf')
+      preserved.preserve_whitespace = true
+
+      expect(squished.text).not_to include "\n"
+      expect(preserved.text).to include "lorem ipsum fulltext find me!\n"
+    end
+
     it 'should extract umlauts correctly into UTF-8' do
       file = File.new('spec/fixtures/files/text-with-umlaut.pdf', 'r')
 

--- a/spec/lib/file_handler/resolver_spec.rb
+++ b/spec/lib/file_handler/resolver_spec.rb
@@ -15,6 +15,21 @@ describe Plaintext::Resolver do
     expect(resolver.text).to eq("hello world!")
   end
 
+  it 'keeps the whitespace returned by the handler if preserve_whitespace is set' do
+    allow(handler).to receive(:text).and_return("  hello \n \n world! ")
+    resolver.preserve_whitespace = true
+
+    expect(resolver.text).to eq("  hello \n \n world! ")
+  end
+
+  it 'still composes and limits the text if preserve_whitespace is set' do
+    allow(handler).to receive(:text).and_return("In der Küche\n\nist es warm")
+    resolver.preserve_whitespace = true
+    resolver.max_plaintext_bytes = 14
+
+    expect(resolver.text).to eq "In der Küche\n"
+  end
+
   it 'composes decomposed characters' do
     # 'u' followed by a combining diaeresis
     allow(handler).to receive(:text).and_return("In der Küche")


### PR DESCRIPTION
## Motivation

`Resolver#text` collapses all whitespace into single spaces, which is what search indexing wants but discards the structure the extraction commands emit. Consumers that process the extracted text paragraph by paragraph have no way to keep it short of bypassing the `Resolver` entirely.

## What this PR does

Adds a `preserve_whitespace` accessor to `Plaintext::Resolver`. When set, the squish and strip are skipped and nothing else changes.

That yields the document structure for the formats whose handlers already emit one: plain text and everything extracted by an external command (PDF, DOC, XLS, PPT, RTF and images). The text is returned as the handler emits it, so form feeds between PDF pages, `\r\n` line endings and edge whitespace come through as well; the README says so. The zipped XML handlers join their text elements with a space and are unaffected, as discussed below.

It is an accessor rather than a constructor argument, for consistency with the existing `max_plaintext_bytes`.

## Backward compatibility

`preserve_whitespace` defaults to `false`, so the output is unchanged unless it is set. No existing spec was modified; the spec changes are additions only:

- two resolver examples, one for the preserved whitespace and one asserting that composition and the byte limit still apply in preserve mode
- an end-to-end example on the PDF fixture, asserting the line structure survives in preserve mode and that the default output contains no line breaks at all

## Not included

The earlier revision of this PR also keyed a `separator: "\n"` through `ZippedXmlHandler`. As pointed out in review that was wrong: `OfficeDocumentHandler` collects `t` elements, which are runs rather than paragraphs, so the separator landed mid sentence wherever formatting changed, and `XlsxHandler` reads the deduplicated shared string table where separators bear no relation to rows or cells. That plumbing is gone.

Making the zipped XML formats emit real paragraph boundaries needs the separator keyed on the paragraph element instead, which is a bigger change and better done on its own.

