### PR TITLE
Make external command output encoding configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,25 @@ end
 
 Please overwrite `Plaintext::Configuration.load`.
 
+#### Output encoding
+
+The output of each command is read as `ASCII-8BIT` and converted to UTF-8 by
+replacing any non-ASCII byte (the exception is `pdftotext`, which is invoked
+with `-enc UTF-8` and read as UTF-8). If your command already emits UTF-8 —
+like the default `catdoc -dutf-8`, `xls2csv -dutf-8` and `catppt -dutf-8` do —
+you can declare it with the `<command>_encoding` setting to keep accented
+characters intact instead of having them replaced by question marks:
+
+```yml
+catdoc_encoding: UTF-8
+xls2csv_encoding: UTF-8
+catppt_encoding: UTF-8
+```
+
+Any encoding name known to Ruby is accepted and will be converted to UTF-8,
+e.g. `catdoc_encoding: ISO-8859-1`. When not set, the previous behavior is
+kept for backwards compatibility.
+
 ### Linux
 
 On linux the default configuration should work. However, make sure that the following packages are installed

--- a/lib/plaintext/file_handler/external_command_handler.rb
+++ b/lib/plaintext/file_handler/external_command_handler.rb
@@ -15,6 +15,12 @@ module Plaintext
     FILE_PLACEHOLDER = '__FILE__'.freeze
     DEFAULT_STREAM_ENCODING = 'ASCII-8BIT'.freeze
 
+    attr_writer :stream_encoding
+
+    def stream_encoding
+      @stream_encoding || DEFAULT_STREAM_ENCODING
+    end
+
     def shellout(cmd, options = {}, &block)
       mode = "r+"
       IO.popen(cmd, mode) do |io|
@@ -46,7 +52,7 @@ module Plaintext
     protected
 
     def utf8_stream?
-      false
+      stream_encoding.casecmp('UTF-8').zero?
     end
 
     private
@@ -54,11 +60,7 @@ module Plaintext
     def set_stream_encoding(io)
       return unless io.respond_to?(:set_encoding)
 
-      if utf8_stream?
-        io.set_encoding('UTF-8'.freeze)
-      else
-        io.set_encoding(DEFAULT_STREAM_ENCODING)
-      end
+      io.set_encoding(stream_encoding)
     end
 
     def read(io, max_size = nil)
@@ -67,7 +69,7 @@ module Plaintext
       if utf8_stream?
         piece
       else
-        Plaintext::CodesetUtil.to_utf8 piece, DEFAULT_STREAM_ENCODING
+        Plaintext::CodesetUtil.to_utf8 piece, stream_encoding
       end
     end
   end

--- a/lib/plaintext/file_handler/external_command_handler/doc_handler.rb
+++ b/lib/plaintext/file_handler/external_command_handler/doc_handler.rb
@@ -12,6 +12,7 @@ module Plaintext
     def initialize
       @content_types = CONTENT_TYPES
       @command = Plaintext::Configuration['catdoc'] || DEFAULT
+      @stream_encoding = Plaintext::Configuration['catdoc_encoding']
     end
   end
 end

--- a/lib/plaintext/file_handler/external_command_handler/image_handler.rb
+++ b/lib/plaintext/file_handler/external_command_handler/image_handler.rb
@@ -13,6 +13,7 @@ module Plaintext
     def initialize
       @content_types = CONTENT_TYPES
       @command = Plaintext::Configuration['tesseract'] || DEFAULT
+      @stream_encoding = Plaintext::Configuration['tesseract_encoding']
     end
   end
 end

--- a/lib/plaintext/file_handler/external_command_handler/pdf_handler.rb
+++ b/lib/plaintext/file_handler/external_command_handler/pdf_handler.rb
@@ -9,12 +9,7 @@ module Plaintext
     def initialize
       @content_type = 'application/pdf'
       @command = Plaintext::Configuration['pdftotext'] || DEFAULT
-    end
-
-    protected
-
-    def utf8_stream?
-      true
+      @stream_encoding = Plaintext::Configuration['pdftotext_encoding'] || 'UTF-8'
     end
   end
 end

--- a/lib/plaintext/file_handler/external_command_handler/ppt_handler.rb
+++ b/lib/plaintext/file_handler/external_command_handler/ppt_handler.rb
@@ -12,6 +12,7 @@ module Plaintext
     def initialize
       @content_types = CONTENT_TYPES
       @command = Plaintext::Configuration['catppt'] || DEFAULT
+      @stream_encoding = Plaintext::Configuration['catppt_encoding']
     end
   end
 end

--- a/lib/plaintext/file_handler/external_command_handler/rtf_handler.rb
+++ b/lib/plaintext/file_handler/external_command_handler/rtf_handler.rb
@@ -8,6 +8,7 @@ module Plaintext
     def initialize
       @content_type = 'application/rtf'
       @command = Plaintext::Configuration['unrtf'] || DEFAULT
+      @stream_encoding = Plaintext::Configuration['unrtf_encoding']
     end
 
     private
@@ -29,7 +30,7 @@ module Plaintext
             line[0,max_size]
           end
         end
-        Plaintext::CodesetUtil.to_utf8 string, "ASCII-8BIT"
+        utf8_stream? ? string : Plaintext::CodesetUtil.to_utf8(string, stream_encoding)
       end
     end
   end

--- a/lib/plaintext/file_handler/external_command_handler/xls_handler.rb
+++ b/lib/plaintext/file_handler/external_command_handler/xls_handler.rb
@@ -12,6 +12,7 @@ module Plaintext
     def initialize
       @content_types = CONTENT_TYPES
       @command = Plaintext::Configuration['xls2csv'] || DEFAULT
+      @stream_encoding = Plaintext::Configuration['xls2csv_encoding']
     end
     def text(*_)
       if str = super

--- a/plaintext.yml.example
+++ b/plaintext.yml.example
@@ -39,3 +39,15 @@
 #   - /usr/bin/tesseract
 #   - -dutf-8
 #   - __FILE__
+
+# Encoding of the output of each command. Defaults to ASCII-8BIT (any
+# non-ASCII byte is replaced by a question mark), except for pdftotext
+# which defaults to UTF-8. Declare UTF-8 if your command already emits
+# UTF-8 (like the default catdoc/xls2csv/catppt invocations above) to
+# keep non-ASCII characters intact.
+# catdoc_encoding: UTF-8
+# xls2csv_encoding: UTF-8
+# catppt_encoding: UTF-8
+# unrtf_encoding: UTF-8
+# tesseract_encoding: UTF-8
+# pdftotext_encoding: UTF-8

--- a/spec/fixtures/files/text-with-umlaut-latin1.txt
+++ b/spec/fixtures/files/text-with-umlaut-latin1.txt
@@ -1,0 +1,1 @@
+lorem ipsum In der Küche hat es eine Kaffeemaschine, mañana habrá café

--- a/spec/fixtures/files/text-with-umlaut.txt
+++ b/spec/fixtures/files/text-with-umlaut.txt
@@ -1,0 +1,1 @@
+lorem ipsum In der Küche hat es eine Kaffeemaschine, mañana habrá café

--- a/spec/lib/file_handler/external_command_handler_spec.rb
+++ b/spec/lib/file_handler/external_command_handler_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Plaintext::ExternalCommandHandler do
+  let(:handler_class) do
+    Class.new(described_class) do
+      def initialize
+        @content_type = 'text/plain'
+        @command = ['/bin/cat', Plaintext::ExternalCommandHandler::FILE_PLACEHOLDER]
+      end
+    end
+  end
+  subject(:handler) { handler_class.new }
+
+  if File.executable?('/bin/cat')
+    it 'replaces non-ASCII bytes with question marks by default' do
+      text = handler.text('spec/fixtures/files/text-with-umlaut.txt')
+
+      expect(text).to include 'K??che'
+      expect(text).to include 'ma??ana habr?? caf??'
+    end
+
+    it 'passes the stream through when the command output is declared as UTF-8' do
+      handler.stream_encoding = 'UTF-8'
+      text = handler.text('spec/fixtures/files/text-with-umlaut.txt')
+
+      expect(text).to include 'Küche'
+      expect(text).to include 'mañana habrá café'
+    end
+
+    it 'converts the declared stream encoding to UTF-8' do
+      handler.stream_encoding = 'ISO-8859-1'
+      text = handler.text('spec/fixtures/files/text-with-umlaut-latin1.txt')
+
+      expect(text).to include 'Küche'
+      expect(text).to include 'mañana habrá café'
+    end
+  else
+    warn "#{described_class.name} could not be tested as /bin/cat is not available."
+  end
+
+  describe 'output encoding configuration' do
+    after { Plaintext::Configuration.load }
+
+    it 'reads the output encoding of each command from the configuration' do
+      Plaintext::Configuration.load('catdoc_encoding: UTF-8')
+
+      expect(Plaintext::DocHandler.new.stream_encoding).to eq 'UTF-8'
+    end
+
+    it 'defaults to the previous behavior when not configured' do
+      Plaintext::Configuration.load('')
+
+      expect(Plaintext::DocHandler.new.stream_encoding).to eq 'ASCII-8BIT'
+      expect(Plaintext::PdfHandler.new.stream_encoding).to eq 'UTF-8'
+    end
+  end
+end


### PR DESCRIPTION
## Motivation

The default `catdoc`, `xls2csv` and `catppt` invocations already request UTF-8 output via `-dutf-8`, but `ExternalCommandHandler#read` reads the stream as `ASCII-8BIT` and converts it with `CodesetUtil.to_utf8`, which replaces every non-ASCII byte with a question mark. As a result, accented characters and umlauts that the tools correctly emitted get destroyed: a document containing `In der Küche, mañana habrá café` is extracted as `In der K??che, ma??ana habr?? caf??`. Only `PdfHandler` is exempt today through its hardcoded `utf8_stream?` override.

## What this PR does

- Adds a `stream_encoding` attribute to `ExternalCommandHandler` (default: `ASCII-8BIT`, as before). `utf8_stream?` is now derived from it instead of being a hardcoded boolean, and both `set_stream_encoding` and `read` use it.
- Each handler reads an optional `<command>_encoding` configuration setting: `catdoc_encoding`, `xls2csv_encoding`, `catppt_encoding`, `unrtf_encoding`, `tesseract_encoding`, `pdftotext_encoding`. Declaring `UTF-8` passes the stream through untouched; any other declared encoding (e.g. `ISO-8859-1`) is properly converted to UTF-8 via the existing `CodesetUtil`.
- `RtfHandler` no longer hardcodes `ASCII-8BIT` in its custom `read` and respects the declared encoding as well.
- Documented in the README and `plaintext.yml.example`.

## Backward compatibility

Nothing changes unless a `*_encoding` setting is configured:

- All handlers keep their current default (`ASCII-8BIT`), and `PdfHandler` keeps `UTF-8` — its `utf8_stream? => true` override is replaced by an equivalent default.
- No existing spec was modified. The new spec exercises the handler with `/bin/cat` as the external command (no extra tooling required) and pins the current default behavior explicitly, plus the UTF-8 passthrough and ISO-8859-1 conversion cases with new UTF-8/Latin-1 fixtures.